### PR TITLE
fix: sanitize comment rendering

### DIFF
--- a/packages/tylant/package.json
+++ b/packages/tylant/package.json
@@ -31,9 +31,11 @@
   ],
   "scripts": {},
   "dependencies": {
-    "bcp-47": "^2.1.0"
+    "bcp-47": "^2.1.0",
+    "sanitize-html": "^2.17.5"
   },
   "devDependencies": {
+    "@types/sanitize-html": "^2.16.1",
     "astro": "^6.4.8"
   },
   "peerDependencies": {

--- a/packages/tylant/src/components/CommentList.astro
+++ b/packages/tylant/src/components/CommentList.astro
@@ -223,18 +223,45 @@ const addUserAnchor = (user: string) => {
       const email = form.querySelector<HTMLInputElement>(
         "input[name='email']"
       )!;
+      const commentRegion = form.closest<HTMLElement>(".comment-region")!;
+      const textarea = form.querySelector<HTMLTextAreaElement>(
+        "textarea[name='comment']"
+      )!;
 
       email.value = localStorage.getItem("commentMailFrom") || "";
+
+      const appendToComment = (value: string) => {
+        textarea.value += value;
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        textarea.focus();
+      };
+
+      commentRegion
+        .querySelectorAll<HTMLAnchorElement>(".comment-alt[data-user]")
+        .forEach((link) => {
+          link.addEventListener("click", (event) => {
+            event.preventDefault();
+
+            const user = link.dataset.user || "";
+            const commentId = link.dataset.commentId;
+            if (!user && !commentId) {
+              return;
+            }
+
+            const userText = user ? "[user:" + user + "] " : "";
+            const value = commentId
+              ? "[comment:" + commentId + "]\n" + userText
+              : userText;
+
+            appendToComment(value);
+          });
+        });
 
       form.addEventListener("submit", (event) => {
         event.preventDefault();
       });
       submitButton?.addEventListener("click", async () => {
-        const textarea = form.querySelector<HTMLTextAreaElement>(
-          "textarea[name='comment']"
-        );
-
-        const content = textarea!.value;
+        const content = textarea.value;
         if (!content) {
           alert("Please enter a comment");
           return;
@@ -255,7 +282,8 @@ const addUserAnchor = (user: string) => {
               alert(
                 "Comment sent successfully. It will be visible after review."
               );
-              textarea!.value = "";
+              textarea.value = "";
+              textarea.dispatchEvent(new Event("input", { bubbles: true }));
             }
           });
       });
@@ -271,7 +299,7 @@ const addUserAnchor = (user: string) => {
               class="comment-alt"
               href="#comment-form"
               id={addUserAnchor(comment.email)}
-              onclick={`const el = document.querySelector('textarea[name=comment]'); el.value += '[user:${comment.email}] '; el.focus(); return false;`}
+              data-user={comment.email}
             >
               [@]
             </a>
@@ -283,7 +311,8 @@ const addUserAnchor = (user: string) => {
               class="comment-alt"
               href="#comment-form"
               id={`comment-${comment.id}`}
-              onclick={`const el = document.querySelector('textarea[name=comment]'); el.value += '[comment:${comment.id}]\\n[user:${comment.email}] '; el.focus(); return false;`}
+              data-user={comment.email}
+              data-comment-id={comment.id}
             >
               [reply]
             </a>

--- a/packages/tylant/src/components/Typst.ts
+++ b/packages/tylant/src/components/Typst.ts
@@ -1,6 +1,7 @@
 import { NodeCompiler } from "@myriaddreamin/typst-ts-node-compiler";
 import { resolve } from "path";
 import { readFile } from "fs/promises";
+import sanitizeHtml from "sanitize-html";
 
 const projectRoot = process.cwd();
 
@@ -12,6 +13,141 @@ const pdfCompiler = NodeCompiler.create({
   workspace: projectRoot,
   fontArgs: [{ fontPaths: [resolve(projectRoot, "assets/fonts/")] }],
 });
+
+const mathMlTags = [
+  "annotation",
+  "annotation-xml",
+  "maction",
+  "maligngroup",
+  "malignmark",
+  "math",
+  "menclose",
+  "merror",
+  "mfenced",
+  "mfrac",
+  "mi",
+  "mmultiscripts",
+  "mn",
+  "mo",
+  "mover",
+  "mpadded",
+  "mphantom",
+  "mprescripts",
+  "mroot",
+  "mrow",
+  "ms",
+  "mspace",
+  "msqrt",
+  "mstyle",
+  "msub",
+  "msubsup",
+  "msup",
+  "mtable",
+  "mtd",
+  "mtext",
+  "mtr",
+  "munder",
+  "munderover",
+  "none",
+  "semantics",
+];
+
+const mathMlAttributes = [
+  "accent",
+  "accentunder",
+  "align",
+  "bevelled",
+  "class",
+  "close",
+  "columnalign",
+  "columnlines",
+  "columnspan",
+  "columnspacing",
+  "denomalign",
+  "depth",
+  "dir",
+  "display",
+  "displaystyle",
+  "fence",
+  "form",
+  "frame",
+  "framespacing",
+  "height",
+  "largeop",
+  "linethickness",
+  "lspace",
+  "mathvariant",
+  "maxsize",
+  "minsize",
+  "movablelimits",
+  "notation",
+  "numalign",
+  "open",
+  "rowalign",
+  "rowlines",
+  "rowspan",
+  "rowspacing",
+  "rspace",
+  "scriptlevel",
+  "separator",
+  "stretchy",
+  "symmetric",
+  "width",
+];
+
+const mathMlAllowedAttributes = Object.fromEntries(
+  mathMlTags.map((tag) => [tag, mathMlAttributes])
+);
+
+const sanitizeCommentHtml = (html: string) =>
+  sanitizeHtml(html, {
+    allowedTags: [
+      "a",
+      "blockquote",
+      "br",
+      "code",
+      "del",
+      "em",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "hr",
+      "img",
+      "li",
+      "ol",
+      "p",
+      "pre",
+      "strong",
+      "table",
+      "tbody",
+      "td",
+      "th",
+      "thead",
+      "tr",
+      "ul",
+      ...mathMlTags,
+    ],
+    allowedAttributes: {
+      a: ["href", "title", "class"],
+      code: ["class"],
+      img: ["src", "alt", "title"],
+      td: ["align"],
+      th: ["align"],
+      ...mathMlAllowedAttributes,
+    },
+    allowedClasses: {
+      a: ["commentref", "userref"],
+      code: [/^language-[\w-]+$/],
+    },
+    allowedSchemes: ["http", "https", "mailto"],
+    allowedSchemesByTag: {
+      img: ["http", "https"],
+    },
+    allowProtocolRelative: false,
+    parseStyleAttributes: false,
+  });
 
 export async function renderMonthlyPdf(mainFilePath: string): Promise<Buffer> {
   return pdfCompiler.pdf({
@@ -54,7 +190,7 @@ ${backtick}
       return "";
     }
 
-    return result.result?.body() || "";
+    return sanitizeCommentHtml(result.result?.body() || "");
   } catch (error) {
     console.error("Error rendering Typst code:", error);
     return "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,13 @@ importers:
       bcp-47:
         specifier: ^2.1.0
         version: 2.1.0
+      sanitize-html:
+        specifier: ^2.17.5
+        version: 2.17.5
     devDependencies:
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       astro:
         specifier: ^6.4.8
         version: 6.4.8(@types/node@22.15.18)(rollup@4.62.1)
@@ -1274,6 +1280,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1509,6 +1518,9 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -1607,6 +1619,10 @@ packages:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -1622,6 +1638,10 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1762,6 +1782,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@9.1.0:
     resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
@@ -1836,6 +1859,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -1862,6 +1889,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2134,6 +2164,9 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -2283,6 +2316,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.5:
+    resolution: {integrity: sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==}
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
@@ -3750,6 +3786,10 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 17.0.45
@@ -4161,6 +4201,8 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  dayjs@1.11.21: {}
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -4238,6 +4280,8 @@ snapshots:
 
   entities@6.0.0: {}
 
+  entities@7.0.1: {}
+
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
@@ -4298,6 +4342,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -4498,6 +4544,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -4562,6 +4615,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@5.0.0: {}
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -4583,6 +4638,10 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
 
   longest-streak@3.1.0: {}
 
@@ -5030,6 +5089,8 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse-srcset@1.0.2: {}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -5269,6 +5330,16 @@ snapshots:
   run-async@4.0.6: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.5:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.3
 
   sax@1.4.1: {}
 


### PR DESCRIPTION
- Sanitize Typst-rendered comment HTML with sanitize-html.
- Preserve MathML output through explicit tag and attribute allowlists.
- Replace inline comment action handlers with data attributes and scoped event listeners.
